### PR TITLE
Code cleanup. I have removed fast where (with-type ... macro is used already

### DIFF
--- a/Lisp/score4.cl
+++ b/Lisp/score4.cl
@@ -24,23 +24,6 @@
                      expr
                      (expand-call type (binarize expr))))))
 
-;; (defun operation-p (x)
-;;   (member x '(+ 1+ - 1- * /)))
-
-;; (defun clone (sexpr)
-;;   (cond 
-;;     ((listp sexpr)
-;;      (if (null sexpr)
-;;          ()
-;;          (let ((hd (car sexpr))
-;;                (tl (cdr sexpr)))
-;;            ;(format t "hd:~A~%tl:~A~%op:~A~%~%" hd tl (operation-p hd))
-;;            (cond
-;;              ((listp hd) (append (list (clone hd)) (clone tl)))
-;;              ((operation-p hd) (list 'the 'fixnum (cons hd (clone tl))))
-;;              (t (cons hd (clone tl)))))))
-;;     (t sexpr)))
-
 ; in the same vein (speed) we need (in many places) to specify
 ; that the result of an operation fits in a fixnum
 ; so we macro (the fixnum (...))
@@ -60,7 +43,7 @@
                (t sexpr)))
            (operation-p (x)
              (member x '(+ 1+ - 1- * /))))
-    (declare (inline clone operations-p))
+    (declare (inline clone operation-p))
     `(,@(clone sexpr))))
 
 (defmacro at (y x)

--- a/Lisp/score4.cl
+++ b/Lisp/score4.cl
@@ -8,45 +8,60 @@
 ; Give me speed!
 (declaim (optimize (speed 3) (safety 0) (debug 0)))
 
-(defun binarize (expr)
-  (if (and (nthcdr 3 expr)
-           (member (car expr) '(+ - * /)))
-      (destructuring-bind (op a1 a2 . rest) expr
-        (binarize `(,op (,op ,a1 ,a2) ,@rest)))
-      expr))
-
-(defun expand-call (type expr)
-  `(,(car expr) ,@(mapcar #'(lambda (a) 
-                              `(with-type ,type ,a))
-                          (cdr expr))))
-
 (defmacro with-type (type expr)
-  `(the ,type ,(if (atom expr) 
-                   expr
-                   (expand-call type (binarize expr)))))
+  (labels ((binarize (expr)
+             (if (and (nthcdr 3 expr)
+                      (member (car expr) '(+ 1+ - 1- * / incf decf)))
+                 (destructuring-bind (op a1 a2 . rest) expr
+                   (binarize `(,op (,op ,a1 ,a2) ,@rest)))
+                 expr))
+           (expand-call (type expr)
+             `(,(car expr) ,@(mapcar #'(lambda (a) 
+                                         `(with-type ,type ,a))
+                                     (cdr expr)))))
+    (declare (inline binarize expand-call))
+    `(the ,type ,(if (atom expr) 
+                     expr
+                     (expand-call type (binarize expr))))))
 
-(defun operation-p (x)
-  (member x '(+ 1+ - 1- * / incf decf)))
+;; (defun operation-p (x)
+;;   (member x '(+ 1+ - 1- * /)))
 
-(defun clone (sexpr)
-  (cond 
-    ((listp sexpr)
-     (if (null sexpr)
-         ()
-         (let ((hd (car sexpr))
-               (tl (cdr sexpr)))
-                                        ;(format t "hd:~A~%tl:~A~%op:~A~%~%" hd tl (operation-p hd))
-           (cond
-             ((listp hd) (append (list (clone hd)) (clone tl)))
-             ((operation-p hd) (list 'the 'fixnum (cons hd (clone tl))))
-             (t (cons hd (clone tl)))))))
-    (t sexpr)))
+;; (defun clone (sexpr)
+;;   (cond 
+;;     ((listp sexpr)
+;;      (if (null sexpr)
+;;          ()
+;;          (let ((hd (car sexpr))
+;;                (tl (cdr sexpr)))
+;;            ;(format t "hd:~A~%tl:~A~%op:~A~%~%" hd tl (operation-p hd))
+;;            (cond
+;;              ((listp hd) (append (list (clone hd)) (clone tl)))
+;;              ((operation-p hd) (list 'the 'fixnum (cons hd (clone tl))))
+;;              (t (cons hd (clone tl)))))))
+;;     (t sexpr)))
 
 ; in the same vein (speed) we need (in many places) to specify
 ; that the result of an operation fits in a fixnum
 ; so we macro (the fixnum (...))
 (defmacro fast (&rest sexpr)
-  `(,@(clone sexpr)))
+  (labels ((clone (sexpr)
+             (cond 
+               ((listp sexpr)
+                (if (null sexpr)
+                    ()
+                    (let ((hd (car sexpr))
+                          (tl (cdr sexpr)))
+                                        ;(format t "hd:~A~%tl:~A~%op:~A~%~%" hd tl (operation-p hd))
+                      (cond
+                        ((listp hd) (append (list (clone hd)) (clone tl)))
+                        ((operation-p hd) (list 'the 'fixnum (cons hd (clone tl))))
+                        (t (cons hd (clone tl)))))))
+               (t sexpr)))
+           (operation-p (x)
+             (member x '(+ 1+ - 1- * /))))
+    (declare (inline clone operations-p))
+    `(,@(clone sexpr))))
 
 (defmacro at (y x)
   ; we emulate a 6x7 board with a 6x7 = 42 one-dimensional one
@@ -90,12 +105,12 @@
               collect `(setf score (with-type fixnum (+ (at ,y 0) (at ,y 1) (at ,y 2))))
               nconc (loop for x fixnum from 3 to (1- width)
                           ; add the 4th one
-                          collect `(incf score (with-type fixnum (at ,y ,x)))
+                          collect `(with-type fixnum (incf score (at ,y ,x)))
                           ; update counts
                           collect `(myincr)
                           ; if we re still in bounds, remove 1st of the old 4
                           if (/= x (1- width))
-                          collect `(decf score (with-type fixnum (at ,y ,(- x 3)))))))))
+                          collect `(with-type fixnum (decf score (at ,y ,(- x 3)))))))))
 
 (defmacro vertical-spans ()
   ; normal code is...
@@ -118,12 +133,12 @@
                collect `(setf score (with-type fixnum (+ (at 0 ,x) (at 1 ,x) (at 2 ,x))))
                nconc (loop for y fixnum from 3 to (1- height)
                            ; add the 4th one
-                           collect `(incf score (with-type fixnum (at ,y ,x)))
+                           collect `(with-type fixnum (incf score (at ,y ,x)))
                            ; update counts
                            collect `(myincr)
                            ; if we re still in bounds, remove 1st of the old 4
                            if (/= y (1- height))
-                           collect `(decf score (with-type fixnum (at ,(- y 3) ,x))))))))
+                           collect `(with-type fixnum (decf score (at ,(- y 3) ,x))))))))
 
 (defmacro downright-spans ()
 ;
@@ -172,17 +187,17 @@
              (loop for startposTuple in dr
                    do (setf y (car startposTuple)) (setf x (cadr startposTuple))
                    ; first 3 of the total 4 cells
-                   collect `(setf score (with-type fixnum (+ (at ,y ,x) (at ,(fast 1+ y) ,(fast 1+ x)) (at ,(fast + y 2) ,(fast + x 2)))))
+                   collect `(setf score (with-type fixnum (+ (at ,y ,x) (at ,(1+ y) ,(1+ x)) (at ,(+ y 2) ,(+ x 2)))))
                    nconc (loop while (and (<= (+ y 3) (1- height)) (<= (+ x 3) (1- width)))
                                ; add the 4th one
-                               collect `(incf score (with-type fixnum (at ,(fast + y 3) ,(fast + x 3))))
+                               collect `(with-type fixnum (incf score (at ,(+ y 3) ,(+ x 3))))
                                ; update counts
                                collect `(myincr)
                                ; move to next cell
                                do (incf y) (incf x)
                                ; if we re still in bounds, remove 1st of the old 4
                                if (and (<= (+ y 3) (1- height)) (<= (+ x 3) (1- width)))
-                               collect `(decf score (with-type fixnum (at ,(fast 1- y) ,(fast 1- x)))))))))))
+                               collect `(with-type fixnum (decf score (at ,(1- y) ,(1- x)))))))))))
 
 (defmacro downleft-spans ()
 ;
@@ -230,17 +245,17 @@
              (loop for startposTuple in dl
                    do (setf y (car startposTuple)) (setf x (cadr startposTuple))
                    ; first 3 of the total 4 cells
-                   collect `(setf score (with-type fixnum (+ (at ,y ,x) (at ,(fast 1+ y) ,(fast 1- x)) (at ,(fast + y 2) ,(fast - x 2)))))
+                   collect `(setf score (with-type fixnum (+ (at ,y ,x) (at ,(1+ y) ,(1- x)) (at ,(+ y 2) ,(- x 2)))))
                    nconc (loop while (and (<= (+ y 3) (1- height)) (>= (- x 3) 0))
                                ; add the 4th one
-                               collect `(incf score (with-type fixnum (at ,(fast + y 3) ,(fast - x 3))))
+                               collect `(with-type fixnum (incf score (at ,(+ y 3) ,(- x 3))))
                                ; update counts
                                collect `(myincr)
                                ; move to next cell
                                do (incf y) (decf x)
                                ; if we re still in bounds, remove 1st of the old 4
                                if (and (<= (+ y 3) (1- height)) (>= (- x 3) 0))
-                               collect `(decf score (with-type fixnum (at ,(fast 1- y) ,(fast 1+ x)))))))))))
+                               collect `(with-type fixnum (decf score (at ,(1- y) ,(1+ x)))))))))))
 
 (declaim (inline scoreBoard))
 (defun scoreBoard (board)
@@ -265,11 +280,11 @@
       ((/= (aref counts 0) 0) yellowWins)
       ((/= (aref counts 8) 0) orangeWins)
       (t (let* ((forOrange (fast + (aref counts 5)
-                              (* 2 (aref counts 6))
-                              (* 5 (aref counts 7))))
+                                 (* 2 (aref counts 6))
+                                 (* 5 (aref counts 7))))
                 (forYellow (fast + (aref counts 3)
-                              (* 2 (aref counts 2))
-                              (* 5 (aref counts 1))))
+                                 (* 2 (aref counts 2))
+                                 (* 5 (aref counts 1))))
                 (result (fast - forOrange forYellow)))
            (declare (type fixnum forOrange forYellow result))
            result)))))
@@ -278,10 +293,10 @@
 (defun dropDisk (board column color)
   (declare (type (simple-array fixnum (42)) board) (type fixnum column color))
   (loop for y fixnum from (1- height) downto 0
-        do (cond ((= 0 (at y column))
-                  (progn
-                    (setf (at y column) color)
-                    (return-from dropDisk y)))))
+        when (zerop (at y column))
+        do (progn
+             (setf (at y column) color)
+             (return-from dropDisk y)))
   -1)
 
 (defun minimax (maximizeOrMinimize color depth board)
@@ -395,7 +410,6 @@
 ; (load "score4.cl")
 ; (sb-ext:save-lisp-and-die "score4.exe" :executable t :toplevel #'main)
 ;
-; Then, when you spawn "score4.exe",
-; just invoke (main)
+; Then, when you spawn "score4.exe" it automatically invokes (main)
 ;
 ; vim: set expandtab ts=8 sts=2 shiftwidth=2


### PR DESCRIPTION
I did a few bad comits but now it should be clean.

Interesting that on your CPU the Rust code runs faster than D and SBCL while on my Intel Core i7-7700HQ CPU both D and SBCL runs quite a bit faster than the Rust code.

    ======================
    = Running benchmarks =
    ======================
    Benchmarking imperative memoized C++ ...: 0.046000
    Benchmarking imperative C++ ...: 0.058000
    Benchmarking imperative C ...: 0.057000
    Benchmarking imperative Lisp (SBCL) ...: 0.075000
    Benchmarking imperative D ...: 0.079000
    Benchmarking functional Rust ...: 0.095000
    Benchmarking imperative Java ...: 0.196000
    Benchmarking imperative OCaml ...: 0.191000
    Benchmarking functional OCaml ...: 0.331000
    Benchmarking imperative Go ...: 0.274000
    Benchmarking imperative C# ...: 0.368000
    Benchmarking imperative F# ...: 0.435000
    Benchmarking functional F# ...: 0.867000

Would it be possible to specify which compiler versions are used for the benchmarking?
I can make quite a difference sometimes.

I have:

    C and C++ 11.3.0
    D         2.098.0
    SBCL      2.2.11
    Rust      1.65.0
    Java      19.0.1 - openJDK
    OCaml     4.13.1
    Go        1.19.4
    C#        4.0.0.0
    F#        4.0
